### PR TITLE
fix: division by zero error

### DIFF
--- a/src/multiple_value/multiple_value.js
+++ b/src/multiple_value/multiple_value.js
@@ -164,9 +164,17 @@ class MultipleValue extends React.PureComponent {
             percChange = progressPerc - 100;
             valueChange = dataPoint.value - compDataPoint.value;
           } else {
-            return window.alert(
-              'Comparison point can not be zero. Adjust the value to continue'
-            );
+            return (
+              <DataPoint
+                  titlePlacement={config[`title_placement_${dataPoint.name}`]}
+                >
+                <DataPointTitle
+                  color={config[`style_${dataPoint.name}`]}
+                  >
+                  {'Comparison point can not be zero. Adjust the value to continue'}
+                </DataPointTitle>
+              </DataPoint>
+            )
           }
           return (
             <>

--- a/src/multiple_value/multiple_value.js
+++ b/src/multiple_value/multiple_value.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import {ComparisonDataPoint} from './ComparisonDataPoint';
+import { ComparisonDataPoint } from './ComparisonDataPoint';
 import ReactHtmlParser from 'react-html-parser';
 import DOMPurify from 'dompurify';
 
@@ -115,13 +115,13 @@ class MultipleValue extends React.PureComponent {
   handleClick = (cell, event) => {
     cell.link !== undefined
       ? LookerCharts.Utils.openDrillMenu({
-          links: cell.link,
-          event: event,
-        })
+        links: cell.link,
+        event: event,
+      })
       : LookerCharts.Utils.openDrillMenu({
-          links: [],
-          event: event,
-        });
+        links: [],
+        event: event,
+      });
   };
 
   recalculateSizing = () => {
@@ -144,13 +144,15 @@ class MultipleValue extends React.PureComponent {
   };
 
   render() {
-    const {config, data} = this.props;
+    const { config, data } = this.props;
+    let message;
+    let display = false;
 
     return (
       <DataPointsWrapper
         layout={this.getLayout()}
         font={config['grouping_font']}
-        style={{fontSize: `${this.state.fontSize}em`}}
+        style={{ fontSize: `${this.state.fontSize}em` }}
       >
         {data.map((dataPoint, index) => {
           const compDataPoint = dataPoint.comparison;
@@ -158,22 +160,18 @@ class MultipleValue extends React.PureComponent {
           let percChange;
           let valueChange;
           if (compDataPoint < 0 || compDataPoint > 0) {
+            display = false;
             progressPerc = Math.round(
               (dataPoint.value / compDataPoint.value) * 100
             );
             percChange = progressPerc - 100;
             valueChange = dataPoint.value - compDataPoint.value;
-          } else {
-            return (
-              <DataPoint
-                  titlePlacement={config[`title_placement_${dataPoint.name}`]}
-                >
-                <DataPointTitle
-                  color={config[`style_${dataPoint.name}`]}
-                  >
-                  {'Comparison point can not be zero. Adjust the value to continue'}
-                </DataPointTitle>
-              </DataPoint>
+          } else if (compDataPoint === 0 || compDataPoint === null) {
+            display = true;
+            message = (
+              <a>
+                {'Comparison point can not be zero. Adjust the value to continue.'}
+              </a>
             )
           }
           return (
@@ -225,6 +223,7 @@ class MultipleValue extends React.PureComponent {
             </>
           );
         })}
+        {display && message}
       </DataPointsWrapper>
     );
   }


### PR DESCRIPTION
This PR contains the fix for blank screens that occurrs when dividing by zero and also still contains the previous fix for links in the iframe to show up in a different tab.